### PR TITLE
Ticket access

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
     "react-material-symbols": "^4.4.0",
+    "react-qr-code": "^2.0.15",
     "react-query": "^3.39.3",
     "react-toastify": "^10.0.5",
     "tailwind-merge": "^2.5.2",

--- a/src/app/event/Modal.tsx
+++ b/src/app/event/Modal.tsx
@@ -35,7 +35,6 @@ export function Modal({ eventId }: { eventId: string }) {
     const nonEmptyAddresses = data.addresses.filter(
       (element) => element.address !== ""
     );
-    console.log("Form submitted with data:", nonEmptyAddresses);
     setOpen(false);
 
     const tickets = nonEmptyAddresses.map((element) => {
@@ -44,8 +43,6 @@ export function Modal({ eventId }: { eventId: string }) {
         eventId: eventId,
       };
     });
-
-    console.log("Attesting tickets", tickets);
 
     createTicketMultiAttestations({ tickets: tickets });
   }

--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -43,6 +43,12 @@ export default function Page({ params }: { params: { id: string } }) {
     "d, MMMM, yyyy 'at' ha."
   );
 
+  if (eventData.access) {
+    console.log("there is access:", eventData.access);
+  } else {
+    console.log("there is no access:");
+  }
+
   const userIsEventOwner = account.address === eventData.owner;
 
   return (

--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -43,12 +43,6 @@ export default function Page({ params }: { params: { id: string } }) {
     "d, MMMM, yyyy 'at' ha."
   );
 
-  if (eventData.access) {
-    console.log("there is access:", eventData.access);
-  } else {
-    console.log("there is no access:");
-  }
-
   const userIsEventOwner = account.address === eventData.owner;
 
   return (

--- a/src/app/event/components/PageComponents.tsx
+++ b/src/app/event/components/PageComponents.tsx
@@ -79,7 +79,7 @@ export const OtherInfoSection = ({
               </TabsTrigger>
             ) : undefined}
           </TabsList>
-          <Modal eventId={eventId} />
+          {userIsEventOwner ? <Modal eventId={eventId} /> : undefined}
         </OtherInfoHeaderContainer>
         <TabsContent value="about">
           <span>Description</span>: {eventData!.fullDescription}
@@ -95,7 +95,9 @@ export const OtherInfoSection = ({
         ) : undefined}
         {userHasTicket ? (
           <TabsContent value="myTicket">
-            <UserTicket eventData={eventData} userTicket={userTicket} />
+            <div className="w-full flex items-center justify-center">
+              <UserTicket eventData={eventData} userTicket={userTicket} />
+            </div>
           </TabsContent>
         ) : undefined}
       </Tabs>

--- a/src/app/event/components/UserTicket.tsx
+++ b/src/app/event/components/UserTicket.tsx
@@ -1,8 +1,8 @@
-import { CopyToClipboard } from "react-copy-to-clipboard";
-import { Copy, Check } from "lucide-react";
 import clsx from "clsx";
 import { useState } from "react";
 import type { Event } from "@/hooks/useCreateEventAttestation";
+import QRCode from "react-qr-code";
+import { MaterialSymbol } from "react-material-symbols";
 
 export type TicketInfoType =
   | {
@@ -13,6 +13,40 @@ export type TicketInfoType =
     }
   | undefined;
 
+const ButtonCopyToClipBoard = ({
+  contentToCopy,
+  buttonText,
+  className,
+}: {
+  contentToCopy: string;
+  buttonText: string;
+  className: string;
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <button
+      onClick={() => copyToClipboard(contentToCopy)}
+      className={className}
+    >
+      {copied ? (
+        <MaterialSymbol icon="check" size={18} />
+      ) : (
+        <MaterialSymbol icon="content_copy" size={18} />
+      )}
+      {buttonText}
+    </button>
+  );
+};
+
 const TruncateAndCopyText = ({
   text,
   className,
@@ -22,13 +56,6 @@ const TruncateAndCopyText = ({
   maxWidth: number;
   className?: string;
 }) => {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = () => {
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1000);
-  };
-
   return (
     <div className="flex items-center space-x-2">
       <p
@@ -41,18 +68,11 @@ const TruncateAndCopyText = ({
       >
         {text}
       </p>
-      <CopyToClipboard text={text} onCopy={handleCopy}>
-        <button
-          className="p-1 rounded hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          aria-label="Copy to clipboard"
-        >
-          {copied ? (
-            <Check className="w-4 h-4 text-green-500" />
-          ) : (
-            <Copy className="w-4 h-4" />
-          )}
-        </button>
-      </CopyToClipboard>
+      <ButtonCopyToClipBoard
+        className="p-1 rounded hover:bg-gray-200 focus:outline-none"
+        contentToCopy={text}
+        buttonText=""
+      />
     </div>
   );
 };
@@ -90,8 +110,8 @@ export const UserTicket = ({
     : { date: undefined, time: undefined };
 
   return (
-    <div className="flex items-start justify-start w-full border-2 rounded-3xl p-8 mt-4">
-      <div key="qrcode" className="w-48 h-48 bg-slate-600 flex-none"></div>
+    <div className="flex items-start justify-start w-full border-2 rounded-3xl p-8 mt-8">
+      <QRCode className="w-48 h-48 flex-none" value={eventData?.access || ""} />
       <div className="flex flex-col justify-center items-start w-full pr-2 pl-2 pt-0 ml-8">
         <div className="flex items-center justify-between w-full pb-4 border-b-2 border-dashed">
           <h1 className="text-2xl font-bold">{eventData?.name}</h1>
@@ -125,9 +145,11 @@ export const UserTicket = ({
           </div>
         </div>
         <div className="w-full flex items-center justify-center">
-          <button className="bg-red-600 rounded-xl mt-6 px-16 py-2 text-white hover:bg-red-800">
-            View Event Access
-          </button>
+          <ButtonCopyToClipBoard
+            className="flex justify-center items-center gap-2 bg-gray-600 rounded-xl mt-5 px-16 py-2 text-white hover:bg-gray-800"
+            contentToCopy={eventData?.access || ""}
+            buttonText="Copy access to clipboard"
+          />
         </div>
       </div>
     </div>

--- a/src/app/event/components/UserTicket.tsx
+++ b/src/app/event/components/UserTicket.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { Event } from "@/hooks/useCreateEventAttestation";
 import QRCode from "react-qr-code";
 import { MaterialSymbol } from "react-material-symbols";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 
 export type TicketInfoType =
   | {
@@ -22,16 +23,9 @@ const ButtonCopyToClipBoard = ({
   buttonText: string;
   className: string;
 }) => {
-  const [copied, setCopied] = useState(false);
-
-  const copyToClipboard = async (text: string) => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
-  };
-
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    copiedEffectTimeMs: 2000,
+  });
   return (
     <button
       onClick={() => copyToClipboard(contentToCopy)}

--- a/src/app/event/components/UserTicket.tsx
+++ b/src/app/event/components/UserTicket.tsx
@@ -110,7 +110,7 @@ export const UserTicket = ({
     : { date: undefined, time: undefined };
 
   return (
-    <div className="flex items-start justify-start w-full border-2 rounded-3xl p-8 mt-8">
+    <div className="flex items-start justify-start w-full max-w-[1000px] border-2 rounded-3xl p-8 mt-8">
       <QRCode className="w-48 h-48 flex-none" value={eventData?.access || ""} />
       <div className="flex flex-col justify-center items-start w-full pr-2 pl-2 pt-0 ml-8">
         <div className="flex items-center justify-between w-full pb-4 border-b-2 border-dashed">

--- a/src/app/event/hooks/useCopyToClipboard.ts
+++ b/src/app/event/hooks/useCopyToClipboard.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from "react";
+
+export const useCopyToClipboard = ({
+  copiedEffectTimeMs,
+}: {
+  copiedEffectTimeMs: number;
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = useCallback(
+    async (text: string) => {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, copiedEffectTimeMs);
+    },
+    [copiedEffectTimeMs]
+  );
+
+  return { copied, copyToClipboard };
+};

--- a/src/app/events/new/components/FormContainer.tsx
+++ b/src/app/events/new/components/FormContainer.tsx
@@ -8,7 +8,6 @@ function ContinueButton({
   isContinueEnabled: boolean;
   handleContinue: () => void;
 }) {
-  console.log("isContinueEnabled", isContinueEnabled);
   return (
     <button
       className={clsx(

--- a/src/app/events/new/components/FormContainer.tsx
+++ b/src/app/events/new/components/FormContainer.tsx
@@ -8,11 +8,12 @@ function ContinueButton({
   isContinueEnabled: boolean;
   handleContinue: () => void;
 }) {
+  console.log("isContinueEnabled", isContinueEnabled);
   return (
     <button
       className={clsx(
         "w-52 rounded-xl bg-slate-300 py-2 font-medium text-slate-600",
-        { isContinueEnabled: "hover:bg-red-400 hover:text-white" }
+        { "hover:bg-red-600 hover:text-white": isContinueEnabled }
       )}
       onClick={handleContinue}
       disabled={!isContinueEnabled}

--- a/src/app/events/new/components/FormField.tsx
+++ b/src/app/events/new/components/FormField.tsx
@@ -1,52 +1,53 @@
 import type { FieldError, UseFormRegister } from "react-hook-form";
 
 type ValidFieldNames =
-	| "eventName"
-	| "startsAt"
-	| "startsAtTime"
-	| "endsAt"
-	| "endsAtTime"
-	| "type"
-	| "imageUrl"
-	| "briefDescription"
-	| "fullDescription";
+  | "eventName"
+  | "startsAt"
+  | "startsAtTime"
+  | "endsAt"
+  | "endsAtTime"
+  | "type"
+  | "imageUrl"
+  | "briefDescription"
+  | "fullDescription"
+  | "access";
 
 interface FormFieldProps {
-	className: string;
-	label: string;
-	type: string;
-	placeholder: string;
-	name: ValidFieldNames;
-	register: UseFormRegister<any>; ///////
-	error: FieldError | undefined;
-	valueAsNumber?: boolean;
-	description?: string;
+  className: string;
+  label: string;
+  type: string;
+  placeholder: string;
+  name: ValidFieldNames;
+  register: UseFormRegister<any>; ///////
+  error: FieldError | undefined;
+  valueAsNumber?: boolean;
+  description?: string;
 }
 
 export const FormField: React.FC<FormFieldProps> = ({
-	className,
-	label,
-	type,
-	placeholder,
-	name,
-	description,
-	register,
-	error,
-	valueAsNumber,
+  className,
+  label,
+  type,
+  placeholder,
+  name,
+  description,
+  register,
+  error,
+  valueAsNumber,
 }: FormFieldProps) => {
-	const strongClassName =
-		label === "empty" ? "w-fit text-transparent" : "w-fit";
-	return (
-		<div className="flex flex-col w-fit mb-16">
-			<strong className={strongClassName}>{label}</strong>
-			{description && <span className="text-xs">{description}</span>}
-			<input
-				className={className}
-				type={type}
-				placeholder={placeholder}
-				{...register(name, { valueAsNumber })}
-			/>
-			{error && <span className="error-message">{error.message}</span>}
-		</div>
-	);
+  const strongClassName =
+    label === "empty" ? "w-fit text-transparent" : "w-fit";
+  return (
+    <div className="flex flex-col w-fit mb-16">
+      <strong className={strongClassName}>{label}</strong>
+      {description && <span className="text-xs">{description}</span>}
+      <input
+        className={className}
+        type={type}
+        placeholder={placeholder}
+        {...register(name, { valueAsNumber })}
+      />
+      {error && <span className="error-message">{error.message}</span>}
+    </div>
+  );
 };

--- a/src/app/events/new/forms/Description.tsx
+++ b/src/app/events/new/forms/Description.tsx
@@ -9,11 +9,13 @@ import { z, ZodType } from "zod";
 export interface DescriptionFormData {
   briefDescription: string;
   fullDescription: string;
+  access: string;
 }
 
 const UserSchema: ZodType<DescriptionFormData> = z.object({
   briefDescription: z.string(),
   fullDescription: z.string(),
+  access: z.string(),
 });
 
 export function Description() {
@@ -22,7 +24,7 @@ export function Description() {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors },
     getValues,
   } = useForm<DescriptionFormData>({
     resolver: zodResolver(UserSchema),
@@ -65,6 +67,15 @@ export function Description() {
             </span>
           )}
         </div>
+        <FormField
+          className="w-1000px h-12 mt-1 pl-2 border-2 rounded-lg"
+          label="Access information"
+          type="text"
+          placeholder="Place information people will need to access the event (meeting links, QR code, etc.)"
+          name="access"
+          register={register}
+          error={errors.access}
+        />
       </form>
     </FormContainer>
   );

--- a/src/app/events/new/forms/Description.tsx
+++ b/src/app/events/new/forms/Description.tsx
@@ -71,7 +71,7 @@ export function Description() {
           className="w-1000px h-12 mt-1 pl-2 border-2 rounded-lg"
           label="Access information"
           type="text"
-          placeholder="Place information people will need to access the event (meeting links, QR code, etc.)"
+          placeholder="Place information people will need to access the event (meeting link, QR code address, etc.)"
           name="access"
           register={register}
           error={errors.access}

--- a/src/components/CreateEventSchemaButton.tsx
+++ b/src/components/CreateEventSchemaButton.tsx
@@ -1,15 +1,6 @@
 import { useRegistrySchema } from "@/hooks/useRegistrySchema";
-import { encodePacked, keccak256, zeroAddress } from "viem";
-
-export const CREATE_EVENT_SCHEMA =
-  "address owner, string name, string briefDescription, string fullDescription, string type, uint256 startsAt, uint256 endsAt, string imageUrl";
-
-export const CREATE_EVENT_SCHEMA_UID = keccak256(
-  encodePacked(
-    ["string", "address", "bool"],
-    [CREATE_EVENT_SCHEMA, zeroAddress, true]
-  )
-);
+import { zeroAddress } from "viem";
+import { CREATE_EVENT_SCHEMA } from "@/hooks/useCreateEventAttestation";
 
 export function CreateEventSchemaButton() {
   const registrySchema = useRegistrySchema();

--- a/src/hooks/useCreateEventAttestation.ts
+++ b/src/hooks/useCreateEventAttestation.ts
@@ -1,12 +1,18 @@
 import { useSigner } from "@/hooks/useSigner";
-import { zeroAddress } from "viem";
+import { encodePacked, keccak256, zeroAddress } from "viem";
 import { EAS, SchemaEncoder } from "@ethereum-attestation-service/eas-sdk";
 import { useCallback, useEffect, useState } from "react";
 import type { Address } from "viem";
-import {
-  CREATE_EVENT_SCHEMA,
-  CREATE_EVENT_SCHEMA_UID,
-} from "@/components/CreateEventSchemaButton";
+
+export const CREATE_EVENT_SCHEMA =
+  "address owner, string name, string briefDescription, string fullDescription, string type, uint256 startsAt, uint256 endsAt, string imageUrl, string access";
+
+export const CREATE_EVENT_SCHEMA_UID = keccak256(
+  encodePacked(
+    ["string", "address", "bool"],
+    [CREATE_EVENT_SCHEMA, zeroAddress, true]
+  )
+);
 
 export interface Event {
   owner: Address;
@@ -17,6 +23,7 @@ export interface Event {
   endsAt: number;
   imageUrl: string;
   type: "online" | "inPerson";
+  access: string;
 }
 
 export const CREATE_EVENT_SCHEMA_ENCODER = new SchemaEncoder(
@@ -79,6 +86,11 @@ export const useCreateEventAttestation = () => {
         {
           name: "imageUrl",
           value: encodeURIComponent(event.imageUrl),
+          type: "string",
+        },
+        {
+          name: "access",
+          value: encodeURIComponent(event.access),
           type: "string",
         },
       ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4573,6 +4573,7 @@ __metadata:
     react-dom: "npm:^18"
     react-hook-form: "npm:^7.53.0"
     react-material-symbols: "npm:^4.4.0"
+    react-qr-code: "npm:^2.0.15"
     react-query: "npm:^3.39.3"
     react-toastify: "npm:^10.0.5"
     tailwind-merge: "npm:^2.5.2"
@@ -9482,6 +9483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qr.js@npm:0.0.0":
+  version: 0.0.0
+  resolution: "qr.js@npm:0.0.0"
+  checksum: 10c0/1c6a4c7a58d04e52ec2fee99e39b680fdc5b2a510a981df42c36b716a8eac6634d130fc4d65af8f030f2a07dbf5fa046b97cdfa7456c250ebb50a73916efdcb5
+  languageName: node
+  linkType: hard
+
 "qrcode-generator@npm:^1.4.3":
   version: 1.4.4
   resolution: "qrcode-generator@npm:1.4.4"
@@ -9681,6 +9689,18 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/9399929f2b598a66634c4663fa7703144eeab10c7027f72de7e9af6da6d96f12ead1cc2fdbb09b9aab4d1410b0578d11aa5b7c3db70ffa92fb0329cf181099a5
+  languageName: node
+  linkType: hard
+
+"react-qr-code@npm:^2.0.15":
+  version: 2.0.15
+  resolution: "react-qr-code@npm:2.0.15"
+  dependencies:
+    prop-types: "npm:^15.8.1"
+    qr.js: "npm:0.0.0"
+  peerDependencies:
+    react: "*"
+  checksum: 10c0/6a9d73918623eecbf6204da02bae1851b584f22f0724b2e5cf529a7eee991a757a211822146f670db63c21860ccb2d245b9288f48cd58ca2bff16de0dcdbdb25
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We've decided to stop encrypting ticket access information, since we studied about signing and sending private messages and got to the conclusion it is too complex compared to the project's propose. We'll possibly come back to this later. Until then, the access data (like meeting links) will now be public and part of the event schema.

 So the changes are:
- Add  "access" attribute to the event schema 
- add QR Code in the ticket and a button to copy the access to clipboard

![image](https://github.com/user-attachments/assets/c02ac5a2-e880-4b73-8865-e885e5047784)

How to test:

1. Go to Events > New Event and create a new event with an access data
2. Go to the event details in Events > My Events > <your event>
3. Add a ticket to yourself
4. Reload the page and check your ticket
